### PR TITLE
issue #11: regex on test.py only validates functions that return on first line

### DIFF
--- a/exercises/05-Defining-vs-Calling-a-function/tests.js
+++ b/exercises/05-Defining-vs-Calling-a-function/tests.js
@@ -3,9 +3,9 @@ const fs = require('fs');
 
 
 
-it('Did you create a function named "multi" that expects two parameters?', () => {
+it('Did you create a function named "multi" that expects two parameters and returns a result?', () => {
 
-    const regex = /function\s*multi\s*\((\w+)\s*,\s*(\w+)\s*\)\s*{\s*return\s*\w+\s*\W+\s*\w+\W+\s*}/gm;
+    const regex = /function\s*multi\s*\((\w+)\s*,\s*(\w+)\s*\)\s*{[\s\S]*return[\s\S][^\n]*;\s*}/gm;
     const fileContent = fs.readFileSync('./exercises/05-Defining-vs-Calling-a-function/app.js');
     const match = regex.exec(fileContent);
 


### PR DESCRIPTION
fix on #11 
changes: adjusted regex on test to pass functions named multi, receiving two parameters, returning on first line or after one or more operations.