### PR TITLE
JS Exercise 8 Grammatical Errors (Both Instructions and Tests)

### DIFF
--- a/exercises/08-Function-parameters/README.md
+++ b/exercises/08-Function-parameters/README.md
@@ -9,7 +9,7 @@ The names of the parameters don't matter, but you have to be as explicit as you 
 1. Please write the `renderPerson` function required to print a a string like the following:
 
 ```js
-"Bob is a 23 years old male born in 05/22/1983 with green eyes"
+"Bob is a 23 year old male born on 05/22/1983 with green eyes"
 ```
 
 ## 💡 Hint:

--- a/exercises/08-Function-parameters/tests.js
+++ b/exercises/08-Function-parameters/tests.js
@@ -14,17 +14,17 @@ it("The function 'renderPerson' should return something" , function () {
 });
 
 it("The function 'renderPerson' should return the expected output. Tesing with Bob" , function () {
-    expect(renderPerson('Bob', '05/22/1983', 'green', 23, 'male')).toBe("Bob is a 23 years old male born in 05/22/1983 with green eyes")
+    expect(renderPerson('Bob', '05/22/1983', 'green', 23, 'male')).toBe("Bob is a 23 year old male born on 05/22/1983 with green eyes")
 });
 
 it("The function 'renderPerson' should return the expected output. Tesing with Katherine" , function () {
-    expect(renderPerson('Katherine', '06/05/2004', 'green', 17, 'female')).toBe("Katherine is a 17 years old female born in 06/05/2004 with green eyes")
+    expect(renderPerson('Katherine', '06/05/2004', 'green', 17, 'female')).toBe("Katherine is a 17 year old female born on 06/05/2004 with green eyes")
 });
 
 it("Print the function 'renderPerson' in console to see the result" , function () {
     require("./app.js");
     expect(console.log.mock.calls.length).toBe(1)
-    expect(console.log).toHaveBeenCalledWith("Bob is a 23 years old male born in 05/22/1983 with green eyes");
+    expect(console.log).toHaveBeenCalledWith("Bob is a 23 year old male born on 05/22/1983 with green eyes");
 });
 
 


### PR DESCRIPTION
I fixed grammatical errors in the print statement on exercise 8 for both the instructions and tests. 